### PR TITLE
Migration version validation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,12 @@ version := "1.0"
 
 scalaVersion := "2.12.2"
 
+lazy val scalaTestVersion = "3.0.5"
+
 libraryDependencies ++= Seq(
+  "org.scalactic" %% "scalactic" % scalaTestVersion % "test",
+  "org.scalatest" %% "scalatest" % scalaTestVersion % "test",
+  "org.mockito" % "mockito-all" % "1.8.4" % "test"
 )
 
 

--- a/src/main/scala/com/nat/migrator/Main.scala
+++ b/src/main/scala/com/nat/migrator/Main.scala
@@ -1,5 +1,5 @@
 package com.nat.migrator
 
 object Main extends App {
-  println("This is main class")
+//  println("This is main class")
 }

--- a/src/main/scala/com/nat/migrator/Migration.scala
+++ b/src/main/scala/com/nat/migrator/Migration.scala
@@ -13,12 +13,22 @@ trait Migration {
   /**
     * This method is for initialize database schemas, for safety this method should have side effect on new collections only.
     * The logic of running init schema is depends on current version of database
-    * This method will be call or not depends on the caller
+    * This method will be called or not depends on the caller
     * @param version version string of current schema version, should be identical with other migration
     * @return
     */
-  def initSchemas(): Option[Boolean]
+  def initSchemas(): Either[String, Unit]
 
+  /**
+    * This method is for de-initialize database schemas, for safety this method should have side effect on new collections only.
+    * The logic of running init schema is depends on current version of database
+    * This method will be called or not depends on the caller
+    * @param version version string of current schema version, should be identical with other migration
+    * @return
+    */
+  def deInitSchemas(): Either[String, Unit]
 
+  def migrationUp(): Either[String, Unit]
 
+  def migrationDown(): Either[String, Unit]
 }

--- a/src/main/scala/com/nat/migrator/Migration.scala
+++ b/src/main/scala/com/nat/migrator/Migration.scala
@@ -1,0 +1,24 @@
+package com.nat.migrator
+
+
+trait Migration {
+
+
+  /**
+    * This method should return version that need to be identical
+    * @return
+    */
+  def version: String
+
+  /**
+    * This method is for initialize database schemas, for safety this method should have side effect on new collections only.
+    * The logic of running init schema is depends on current version of database
+    * This method will be call or not depends on the caller
+    * @param version version string of current schema version, should be identical with other migration
+    * @return
+    */
+  def initSchemas(): Option[Boolean]
+
+
+
+}

--- a/src/main/scala/com/nat/migrator/Migrator.scala
+++ b/src/main/scala/com/nat/migrator/Migrator.scala
@@ -1,0 +1,36 @@
+package com.nat.migrator
+
+/**
+  * This trait is responsible for control process of all
+  */
+
+trait Migrator {
+
+  /**
+    * This should contains newest version at the head of the list, and oldest version should be the tail of the list
+    * @return
+    */
+  def migrations: List[Migration]
+
+  def validateMigrations: Option[String] = {
+    migrations
+      .map(_.version)
+      .toSet
+      .size match {
+      case migrations.length => None
+      case _ => Some("There are some duplicated version in migrations, please make sure the version are identical")
+    }
+  }
+
+  def migrate(targetVersion: Option[String]) = {
+    targetVersion match {
+      case None =>
+      case Some(targetVersion) =>
+    }
+  }
+
+  def doMigration(targetVersion: String) = {
+    migrations.find()
+  }
+}
+

--- a/src/main/scala/com/nat/migrator/Migrator.scala
+++ b/src/main/scala/com/nat/migrator/Migrator.scala
@@ -12,6 +12,11 @@ trait Migrator {
     */
   def migrations: List[Migration]
 
+  /**
+    * This method is for validate migration on the following criterias
+    *   - Duplicate version number
+    * @return
+    */
   def validateMigrations: Option[String] = {
     migrations
       .map(_.version)
@@ -29,8 +34,9 @@ trait Migrator {
     }
   }
 
-  def doMigration(targetVersion: String) = {
-    migrations.find()
-  }
+//  def doMigration(targetVersion: String) = {
+//    migrations.find(_.version == targetVersion)
+//      .
+//  }
 }
 

--- a/src/main/scala/com/nat/migrator/Migrator.scala
+++ b/src/main/scala/com/nat/migrator/Migrator.scala
@@ -70,8 +70,8 @@ trait Migrator {
         val currentVersionIndex = migrationVersions.indexOf(currentVersion)
         (targetVersionIndex, currentVersionIndex) match {
           case (-1, -1) | (-1, _) | (_, -1) => Left(List("Unable to find target version, or current version in migration list"))
-          case (tgv, crv) if tgv > crv => Right(MigrationDirectionUp)
-          case (tgv, crv) if tgv < crv => Right(MigrationDirectionDown)
+          case (tgv, crv) if tgv < crv => Right(MigrationDirectionUp)
+          case (tgv, crv) if tgv > crv => Right(MigrationDirectionDown)
           case _ => Right(MigrationDirectionSame)
         }
       }

--- a/src/main/scala/com/nat/migrator/Migrator.scala
+++ b/src/main/scala/com/nat/migrator/Migrator.scala
@@ -1,5 +1,7 @@
 package com.nat.migrator
 
+import com.nat.migrator.model._
+
 /**
   * This trait is responsible for control process of all
   */
@@ -17,7 +19,13 @@ trait Migrator {
     *
     * @return
     */
-  def currentVersion: Option[String]
+  def loadCurrentVersionNumber: Option[String]
+
+  /**
+    * Validate instance's migration object
+    * @return
+    */
+  def validateMigrations: List[String] = validateMigrations(migrations)
 
 
   /**
@@ -25,9 +33,9 @@ trait Migrator {
     *   - Duplicate version number
     * @return
     */
-  def validateMigrations: List[String] = {
+  def validateMigrations(validatingMigration: List[Migration]): List[String] = {
     val identicalVersions =
-      migrations
+      validatingMigration
         .map(_.version)
         .toSet
         .size
@@ -45,16 +53,153 @@ trait Migrator {
 
   }
 
-  def migrate(targetVersion: Option[String]) = {
-    targetVersion match {
-      case None =>
-      case Some(targetVersion) =>
+  /**
+    * Automatically detect migration direction,
+    *   - migration up if target version index is below current version
+    *   - migration down if target version index is current target version
+    *   - migration none if target version is the same as current version
+    * @param targetVersion
+    * @param currentVersion
+    * @return
+    */
+  def findMigrationDirection(targetVersion: String, currentVersion: String, migrations: List[Migration]): Either[List[String],MigrationDirection] = {
+    validateMigrations(migrations) match {
+      case Nil => {
+        val targetVersionIndex = migrations.map(_.version).indexOf(targetVersion)
+        val currentVersionIndex = migrations.map(_.version).indexOf(currentVersion)
+        if( targetVersionIndex < currentVersionIndex ) Right(MigrationDirectionUp)
+        else if ( targetVersionIndex > currentVersionIndex ) Right(MigrationDirectionDown)
+        else Right(MigrationDirectionSame)
+      }
+      case errors => Left(errors)
     }
   }
 
-//  def doMigration(targetVersion: String) = {
-//    migrations.find(_.version == targetVersion)
-//      .
-//  }
+  /**
+    * Find portion of migration list only interested version
+    * @param allMigrations
+    * @param targetVersion
+    * @param currentVersion
+    * @return
+    */
+  def findInterestedMigrations(allMigrations: List[Migration], targetVersion: String, currentVersion: String): Either[String, List[Migration]] = {
+    val onlyVersions = allMigrations.map(_.version)
+    (onlyVersions.indexOf(targetVersion), onlyVersions.indexOf(currentVersion)) match {
+      case (-1, -1) => Left(s"Both $targetVersion, and $currentVersion are not exists")
+      case (-1, _) => Left(s"$targetVersion is not exists")
+      case (_, -1) => Left(s"$currentVersion is not exists")
+      case (tgi, cri) if tgi > cri => Right(allMigrations.slice(cri, tgi + 1))
+      case (tgi, cri) => Right(allMigrations.slice(tgi, cri + 1))
+    }
+  }
+
+  /**
+    * Migrate with the following logic
+    * - If no version provide => detect current version, and migrate to the latest version
+    * - If version is provide
+    *   - the current version, and target version is the same => return fail with no change
+    *   - the current version is lower than target version => do migration up
+    *   - the current version is higher than target version => do migration down
+    * - If unable to load current version => do upgrade to current version
+    * @param targetVersion
+    * @return
+    */
+  def migrate(targetVersion: Option[String]): MigrationResult = {
+    targetVersion match {
+      case None =>
+        migrations
+          .headOption
+          .map(tg => migrate(Some(tg.version)))
+          .getOrElse(MigrationResultFailed("Empty migration"))
+      case Some(tgv) =>
+        loadCurrentVersionNumber
+          .map { currentVer =>
+            (currentVer, findMigrationDirection(tgv, currentVer, migrations))
+          }
+          .map { tup =>
+            val currentVer = tup._1
+            findInterestedMigrations(migrations, tgv, currentVer)
+              .map { interestedMigration =>
+                tup._2 match {
+                  case Right(MigrationDirectionSame) => MigrationResultFailed(s"target version, and current version is the same (targetVersion = $targetVersion")
+                  case Right(MigrationDirectionUp) => runSortedMigration(interestedMigration.reverse, MigrationDirectionUp)
+                  case Right(MigrationDirectionDown) => runSortedMigration(interestedMigration, MigrationDirectionDown)
+                  case Left(errors) => MigrationResultFailed(s"Migration collection does not pass validation $errors")
+                }
+              }
+              .fold(
+                err => MigrationResultFailed(err),
+                identity
+              )
+          }
+          .getOrElse(migrate(None))
+    }
+  }
+
+  /**
+    * Running sorted migration from one by one, terminate when any failed happen
+    * @Preconditions Migration must be sorted and ready to execute from head to tail
+    * @param pendingSortedMigration
+    * @param migrationDirection
+    * @return
+    */
+  def runSortedMigration(pendingSortedMigration: List[Migration], migrationDirection: MigrationDirectionDifferent): MigrationResult = {
+    pendingSortedMigration match {
+      case Nil => MigrationResultSuccess
+      case head :: remaining => {
+        val migrationFn = migrationDirection match {
+          case MigrationDirectionUp => runMigrationUp _
+          case MigrationDirectionDown => runMigrationDown _
+        }
+        migrationFn(head) match {
+          case MigrationResultSuccess => runSortedMigration(remaining, migrationDirection)
+          case failed => failed
+        }
+      }
+    }
+  }
+
+  /**
+    * Run a migration
+    * @param pendingMigration
+    * @param migrationDirection
+    * @return
+    */
+  def runMigration(pendingMigration: Migration, migrationDirection: MigrationDirectionDifferent): MigrationResult = {
+    migrationDirection match {
+      case MigrationDirectionUp => runMigrationUp(pendingMigration)
+      case MigrationDirectionDown => runMigrationDown(pendingMigration)
+    }
+  }
+
+  /**
+    * Run a migration up
+    * @param migration
+    * @return
+    */
+  def runMigrationUp(migration: Migration): MigrationResult = {
+    migration
+      .initSchemas()
+      .flatMap(_ => migration.migrationUp())
+      .fold[MigrationResult](
+        rs => MigrationResultFailed(rs),
+        _ => MigrationResultSuccess
+      )
+  }
+
+  /**
+    * Run a migration down
+    * @param migration
+    * @return
+    */
+  def runMigrationDown(migration: Migration): MigrationResult = {
+    migration
+      .deInitSchemas()
+      .flatMap(_ => migration.migrationDown())
+      .fold[MigrationResult](
+        rs => MigrationResultFailed(rs),
+        _ => MigrationResultSuccess
+      )
+  }
 }
 

--- a/src/main/scala/com/nat/migrator/Migrator.scala
+++ b/src/main/scala/com/nat/migrator/Migrator.scala
@@ -134,7 +134,7 @@ trait Migrator {
                   identity
                 )
           }
-          .getOrElse(migrate(None))
+          .getOrElse(MigrationResultFailed("Unable to get current version"))
     }
   }
 

--- a/src/main/scala/com/nat/migrator/Migrator.scala
+++ b/src/main/scala/com/nat/migrator/Migrator.scala
@@ -109,7 +109,6 @@ trait Migrator {
     * @return
     */
   def migrate(targetVersion: Option[String]): MigrationResult = {
-    println(s"migrating to version $targetVersion")
     (migrations, targetVersion) match {
       case (Nil, _ ) => MigrationResultFailed("Empty migration")
       case (head :: _, None) => migrate(Some(head.version))

--- a/src/main/scala/com/nat/migrator/Migrator.scala
+++ b/src/main/scala/com/nat/migrator/Migrator.scala
@@ -12,6 +12,14 @@ trait Migrator {
     */
   def migrations: List[Migration]
 
+
+  /** Implement this methods to see which is the current version of database"
+    *
+    * @return
+    */
+  def currentVersion: Option[String]
+
+
   /**
     * This method is for validate migration on the following criterias
     *   - Duplicate version number

--- a/src/main/scala/com/nat/migrator/Migrator.scala
+++ b/src/main/scala/com/nat/migrator/Migrator.scala
@@ -17,14 +17,24 @@ trait Migrator {
     *   - Duplicate version number
     * @return
     */
-  def validateMigrations: Option[String] = {
-    migrations
-      .map(_.version)
-      .toSet
-      .size match {
-      case migrations.length => None
-      case _ => Some("There are some duplicated version in migrations, please make sure the version are identical")
+  def validateMigrations: List[String] = {
+    val identicalVersions =
+      migrations
+        .map(_.version)
+        .toSet
+        .size
+
+    if(identicalVersions == migrations.length)
+      Nil
+    else {
+      migrations
+        .groupBy(_.version)
+        .collect {
+          case (ves, items) if items.length > 1 => ves
+        }
+        .toList
     }
+
   }
 
   def migrate(targetVersion: Option[String]) = {

--- a/src/main/scala/com/nat/migrator/model/MigrationDirection.scala
+++ b/src/main/scala/com/nat/migrator/model/MigrationDirection.scala
@@ -1,0 +1,7 @@
+package com.nat.migrator.model
+
+sealed trait MigrationDirection
+sealed trait MigrationDirectionDifferent extends MigrationDirection
+case object MigrationDirectionUp extends MigrationDirectionDifferent
+case object MigrationDirectionDown extends MigrationDirectionDifferent
+case object MigrationDirectionSame extends MigrationDirection

--- a/src/main/scala/com/nat/migrator/model/MigrationResult.scala
+++ b/src/main/scala/com/nat/migrator/model/MigrationResult.scala
@@ -1,0 +1,5 @@
+package com.nat.migrator.model
+
+sealed trait MigrationResult
+case object MigrationResultSuccess extends MigrationResult
+case class MigrationResultFailed(reason: String) extends MigrationResult

--- a/src/test/scala/com/nat/migrator/MigrationSpec.scala
+++ b/src/test/scala/com/nat/migrator/MigrationSpec.scala
@@ -1,0 +1,5 @@
+package com.nat.migrator
+
+class MigrationSpec {
+
+}

--- a/src/test/scala/com/nat/migrator/MigrationSpec.scala
+++ b/src/test/scala/com/nat/migrator/MigrationSpec.scala
@@ -5,21 +5,4 @@ import org.scalatest.mockito.MockitoSugar
 import org.mockito.Mockito._
 
 
-class MigrationSpec
-  extends FreeSpec
-  with BeforeAndAfter
-  with MockitoSugar
-{
-
-  "Validating migration data" - {
-
-    "should error when version contains duplicate version number" in {
-
-      val migrationV1 = mock[Migration]
-
-      when(migrationV1.version).thenReturn("1.0.0")
-
-    }
-
-  }
-}
+class MigrationSpec {}

--- a/src/test/scala/com/nat/migrator/MigrationSpec.scala
+++ b/src/test/scala/com/nat/migrator/MigrationSpec.scala
@@ -1,5 +1,25 @@
 package com.nat.migrator
 
-class MigrationSpec {
+import org.scalatest.{BeforeAndAfter, FreeSpec, FunSuite}
+import org.scalatest.mockito.MockitoSugar
+import org.mockito.Mockito._
 
+
+class MigrationSpec
+  extends FreeSpec
+  with BeforeAndAfter
+  with MockitoSugar
+{
+
+  "Validating migration data" - {
+
+    "should error when version contains duplicate version number" in {
+
+      val migrationV1 = mock[Migration]
+
+      when(migrationV1.version).thenReturn("1.0.0")
+
+    }
+
+  }
 }

--- a/src/test/scala/com/nat/migrator/MigratorSpec.scala
+++ b/src/test/scala/com/nat/migrator/MigratorSpec.scala
@@ -1,0 +1,5 @@
+package com.nat.migrator
+
+class MigratorSpec {
+
+}

--- a/src/test/scala/com/nat/migrator/MigratorSpec.scala
+++ b/src/test/scala/com/nat/migrator/MigratorSpec.scala
@@ -11,9 +11,9 @@ class MigratorSpec extends FreeSpec
 
   "Validating migration data" - {
 
-    "should error when version contains duplicate version number" in {
+    "should return all duplicated version when any migration contains duplicate version" in {
       val mgs =
-        List("1.0.0", "1.0.0")
+        List("1.0.0", "1.0.0", "1.0.1", "1.2.0", "1.2.0")
           .map { version =>
             val mg = mock[Migration]
             when(mg.version).thenReturn(version)
@@ -25,7 +25,7 @@ class MigratorSpec extends FreeSpec
       }
 
       migrator.validateMigrations match {
-        case "1.0.0" :: Nil => assert(true)
+        case "1.0.0" :: "1.2.0" :: Nil => assert(true)
         case _ => assert(false)
       }
 
@@ -50,6 +50,5 @@ class MigratorSpec extends FreeSpec
       }
 
     }
-
   }
 }

--- a/src/test/scala/com/nat/migrator/MigratorSpec.scala
+++ b/src/test/scala/com/nat/migrator/MigratorSpec.scala
@@ -1,5 +1,55 @@
 package com.nat.migrator
 
-class MigratorSpec {
+import org.mockito.Mockito.when
+import org.scalatest.{BeforeAndAfter, FreeSpec}
+import org.scalatest.mockito.MockitoSugar
 
+class MigratorSpec extends FreeSpec
+  with BeforeAndAfter
+  with MockitoSugar
+{
+
+  "Validating migration data" - {
+
+    "should error when version contains duplicate version number" in {
+      val mgs =
+        List("1.0.0", "1.0.0")
+          .map { version =>
+            val mg = mock[Migration]
+            when(mg.version).thenReturn(version)
+            mg
+          }
+
+      val migrator = new Migrator {
+        override def migrations: List[Migration] = mgs
+      }
+
+      migrator.validateMigrations match {
+        case "1.0.0" :: Nil => assert(true)
+        case _ => assert(false)
+      }
+
+    }
+
+    "should pass when no no duplicate version" in {
+      val mgs =
+        List("1.0.0", "1.0.1")
+          .map { version =>
+            val mg = mock[Migration]
+            when(mg.version).thenReturn(version)
+            mg
+          }
+
+      val migrator = new Migrator {
+        override def migrations: List[Migration] = mgs
+      }
+
+      migrator.validateMigrations match {
+        case Nil => assert(true)
+        case _ => assert(false)
+      }
+
+    }
+
+  }
 }

--- a/src/test/scala/com/nat/migrator/MigratorSpec.scala
+++ b/src/test/scala/com/nat/migrator/MigratorSpec.scala
@@ -63,6 +63,7 @@ class MigratorSpec extends FreeSpec
         when(mockedMigration.version).thenReturn(versionNumber)
         mockedMigration
       }}
+      .reverse
       .toList
 
     object successMigrator extends Migrator {

--- a/src/test/scala/com/nat/migrator/MigratorSpec.scala
+++ b/src/test/scala/com/nat/migrator/MigratorSpec.scala
@@ -55,6 +55,95 @@ class MigratorSpec extends FreeSpec
     }
   }
 
+  "Find migration direction" - {
+
+    val mockedMigrations: List[Migration] = (1 to 5).map(digit => s"1.0.$digit")
+      .map { versionNumber => {
+        val mockedMigration = mock[Migration]
+        when(mockedMigration.version).thenReturn(versionNumber)
+        mockedMigration
+      }}
+      .toList
+
+    object successMigrator extends Migrator {
+      override def migrations: List[Migration] = ???
+      override def loadCurrentVersionNumber: Option[String] = ???
+      override def validateMigrations(validatingMigration: List[Migration]) = Nil
+    }
+
+    object failMigrator extends Migrator {
+      override def migrations: List[Migration] = ???
+      override def loadCurrentVersionNumber: Option[String] = ???
+      override def validateMigrations(validatingMigration: List[Migration]) = "anyError" :: Nil
+    }
+
+    "should failed when validation error regarding correct version or not" in {
+      // 1 incorrect version
+      assert(failMigrator.findMigrationDirection("1.0.1", "1.0.0", mockedMigrations) == Left("anyError" :: Nil))
+      // 0 incorrect version
+      assert(failMigrator.findMigrationDirection("1.0.1", "1.0.2", mockedMigrations) == Left("anyError" :: Nil))
+      // 2 incorrect versions
+      assert(failMigrator.findMigrationDirection("2.0.1", "2.0.0", mockedMigrations) == Left("anyError" :: Nil))
+    }
+
+    "should failed when validation success, and any version is not exists" in {
+      val res = Left(List("Unable to find target version, or current version in migration list"))
+      // 1 incorrect version
+      assert(successMigrator.findMigrationDirection("1.0.1", "1.0.0", mockedMigrations) == res)
+      // 2 incorrect versions
+      assert(successMigrator.findMigrationDirection("2.0.1", "2.0.0", mockedMigrations) == res)
+    }
+
+    "should return correct migration direction when there is no other error happen" - {
+      "migration direction up" in {
+        assert(successMigrator.findMigrationDirection("1.0.5", "1.0.1", mockedMigrations) == Right(MigrationDirectionUp))
+        assert(successMigrator.findMigrationDirection("1.0.4", "1.0.3", mockedMigrations) == Right(MigrationDirectionUp))
+      }
+
+      "migration direction same" in {
+        assert(successMigrator.findMigrationDirection("1.0.4", "1.0.4", mockedMigrations) == Right(MigrationDirectionSame))
+        assert(successMigrator.findMigrationDirection("1.0.3", "1.0.3", mockedMigrations) == Right(MigrationDirectionSame))
+      }
+
+      "migration direction down" in {
+        assert(successMigrator.findMigrationDirection("1.0.1", "1.0.4", mockedMigrations) == Right(MigrationDirectionDown))
+        assert(successMigrator.findMigrationDirection("1.0.2", "1.0.3", mockedMigrations) == Right(MigrationDirectionDown))
+      }
+
+
+    }
+
+  }
+
+  "Find interested migration" - {
+
+    val mockedMigrations: List[Migration] = (1 to 5).map(digit => s"1.0.$digit")
+      .map { versionNumber => {
+        val mockedMigration = mock[Migration]
+        when(mockedMigration.version).thenReturn(versionNumber)
+        mockedMigration
+      }}
+      .toList
+
+    val migrator = new Migrator {
+      override def migrations: List[Migration] = ???
+      override def loadCurrentVersionNumber: Option[String] = ???
+    }
+
+    "should error when there is some version in the migration is not exists" in {
+      assert(migrator.findInterestedMigrations(mockedMigrations, "2.0.0", "3.0.0") == Left(s"Both 2.0.0, and 3.0.0 are not exists"))
+      assert(migrator.findInterestedMigrations(mockedMigrations, "2.0.0", "1.0.1") == Left(s"2.0.0 is not exists"))
+      assert(migrator.findInterestedMigrations(mockedMigrations, "1.0.1", "2.0.0") == Left(s"2.0.0 is not exists"))
+    }
+
+    "should slice correctly" in {
+      assert(migrator.findInterestedMigrations(mockedMigrations, "1.0.1", "1.0.3") == Right(mockedMigrations.slice(0, 3)))
+      assert(migrator.findInterestedMigrations(mockedMigrations, "1.0.3", "1.0.1") == Right(mockedMigrations.slice(0, 3)))
+      assert(migrator.findInterestedMigrations(mockedMigrations, "1.0.1", "1.0.1") == Right(mockedMigrations.slice(0, 1)))
+    }
+
+  }
+
   "Run sorted migration" - {
     "should success when there is no migration left in the list" in {
       val migrator = new Migrator {


### PR DESCRIPTION
Because this script is working by providing target version, this means the version in each migration must be identical. This feature will verify that there are no duplication among those version